### PR TITLE
fixed a bug in __PHYSFS_platformCalcUserDir()

### DIFF
--- a/src/physfs_platform_windows.c
+++ b/src/physfs_platform_windows.c
@@ -575,7 +575,7 @@ char *__PHYSFS_platformCalcUserDir(void)
          *  psize. Also note that the second parameter can't be
          *  NULL or the function fails.
          */
-        rc = pGetDir(accessToken, &dummy, &psize);
+        rc = pGetDir(accessToken, NULL, &psize);
         GOTO_IF(rc, PHYSFS_ERR_OS_ERROR, done);  /* should have failed! */
 
         /* Allocate memory for the profile directory */


### PR DESCRIPTION
The call of pGetDir() returned error code 87 (ERROR_INVALID_PARAMETER) and left psize set to 0. That's why the second call to pGetDir() always failed on my machine.

If NULL is passed to the first call, error code 122 (ERROR_INSUFFICIENT_BUFFER) is returned instead and a valid value is written into psize, making the second call successful.

I'm curious that this bug hasn't been found earlier. I'm running latest Windows 10 and maybe the WinAPI behaves somewhat different to previous versions?